### PR TITLE
Crucial bugfixes

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -20,16 +20,20 @@ def main(args: Namespace):
 
     update_loggers()
 
-    with ThreadingTCPServer(
-        (ProxyConfiguration.get_host(), ProxyConfiguration.get_port()), TCPProxyServer
-    ) as tcp_server:
-        logger.info(f"Server started on {ProxyConfiguration.get_address()}")
+    try:
+        with ThreadingTCPServer(
+            (ProxyConfiguration.get_host(), ProxyConfiguration.get_port()), TCPProxyServer
+        ) as tcp_server:
+            logger.info(f"Server started on {ProxyConfiguration.get_address()}")
 
-        try:
-            tcp_server.serve_forever()
-        except KeyboardInterrupt:
-            logger.info("Server shutting down...")
-        finally:
-            tcp_server.server_close()
-            tcp_server.shutdown()
-            logger.info("Server terminated.")
+            try:
+                tcp_server.serve_forever()
+            except KeyboardInterrupt:
+                logger.info("Server shutting down...")
+            finally:
+                tcp_server.server_close()
+                tcp_server.shutdown()
+                logger.info("Server terminated.")
+    except OSError as e:
+        logger.error(f"Error starting server: {e}")
+        exit(1)

--- a/src/server.py
+++ b/src/server.py
@@ -25,7 +25,7 @@ class ThreadingTCPServer(ThreadingMixIn, TCPServer):
     https://docs.python.org/3/library/socketserver.html#socketserver.ThreadingMixIn
     """
 
-    pass
+    daemon_threads = True
 
 
 class TCPProxyServer(StreamRequestHandler):
@@ -100,7 +100,6 @@ class TCPProxyServer(StreamRequestHandler):
                     self.connection.sendall(reply)
                 except BrokenPipeError as e:
                     logger.error(f"Error sending reply: {e}")
-            self.server.shutdown_request(self.request)
 
     def handle_connect(self, dst_address: DetailedAddress) -> None:
         """


### PR DESCRIPTION
Fixes:
- Remove references to finished thread allowing for proper garbage collection (likely cause of bug)
- Fix unhandled exceptions in TCPRelay causing threads to hang/resources not closing properly.
- Resource leaks from improperly closed/unregistered sockets and selectors
- Server not gracefully shutting down on exceptions other than keyboard interrupt